### PR TITLE
Consider only top-level paths in switch

### DIFF
--- a/main.go
+++ b/main.go
@@ -34,7 +34,7 @@ func (p *plugin) WriteMessage(w io.Writer, md *protokit.Descriptor, messages map
 	fmt.Fprintln(w, "	if len(mask.GetPaths()) == 0 {")
 	fmt.Fprintln(w, "		mask = &types.FieldMask{Paths: m.FieldMaskPaths()}")
 	fmt.Fprintln(w, "	}")
-	fmt.Fprintln(w, "	for _, path := range mask.Paths {")
+	fmt.Fprintln(w, "	for _, path := range TopLevelPaths(mask.Paths...) {")
 	fmt.Fprintln(w, "		switch path {")
 	for _, mfd := range md.GetMessageFields() {
 		allPaths = append(allPaths, mfd.GetName())

--- a/utils/generator.go
+++ b/utils/generator.go
@@ -47,6 +47,16 @@ func CleanFieldMask(mask *types.FieldMask) *types.FieldMask {
 	return &types.FieldMask{Paths: CleanPaths(mask.Paths...)}
 }
 
+// TopLevelPaths returns the list of paths
+func TopLevelPaths(paths ...string) []string {
+	topLevel := make([]string, len(paths))
+	for i, path := range paths {
+		parts := strings.SplitN(path, ".", 2)
+		topLevel[i] = parts[0]
+	}
+	return CleanPaths(topLevel...)
+}
+
 // PathsWithPrefix returns the list of paths, each with the given prefix prepended.
 func PathsWithPrefix(prefix string, paths ...string) []string {
 	if !strings.HasSuffix(prefix, ".") {

--- a/utils/utils.generated.go
+++ b/utils/utils.generated.go
@@ -40,6 +40,16 @@ func CleanFieldMask(mask *types.FieldMask) *types.FieldMask {
 	return &types.FieldMask{Paths: CleanPaths(mask.Paths...)}
 }
 
+// TopLevelPaths returns the list of paths
+func TopLevelPaths(paths ...string) []string {
+	topLevel := make([]string, len(paths))
+	for i, path := range paths {
+		parts := strings.SplitN(path, ".", 2)
+		topLevel[i] = parts[0]
+	}
+	return CleanPaths(topLevel...)
+}
+
 // PathsWithPrefix returns the list of paths, each with the given prefix prepended.
 func PathsWithPrefix(prefix string, paths ...string) []string {
 	if !strings.HasSuffix(prefix, ".") {


### PR DESCRIPTION
**Summary:**
<!--
A summary, always referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR addresses yesterday's discussion about the generated code not being able to properly handle nested paths. This PR should be considered as a way to move forward with MVP until we have a consensus about the goals and implementation of `feature/rewrite`.

<!--
Please motivate briefly why it is implemented this way, if that deviates
from the implementation proposal in the referenced issues.
-->

**Changes:**
<!-- What are the changes made in this pull request? -->

- `SetFields` now only ranges over the top level paths of the field path
- If a field is a message, the sub-field-paths are filtered (so for field `a`, `a.b,a.c` is converted to `b,c`) and we delegate to the sub-message's `SetFields`



