### PR TITLE
Expose field mask paths and remove obsolete method

### DIFF
--- a/main.go
+++ b/main.go
@@ -547,22 +547,12 @@ func (dst *%s) SetFields(src *%s, paths ...string) error {
 	sort.Strings(topLevelPaths)
 
 	fmt.Fprintf(buf, `
-var _%sFieldPathsNested = [...]string{
+var %sFieldPathsNested = []string{
 	%s
 }
 
-var _%sFieldPathsTopLevel = [...]string{
+var %sFieldPathsTopLevel = []string{
 	%s
-}
-
-func (*%s) FieldMaskPaths(nested bool) []string {
-	paths := _%sFieldPathsTopLevel[:]
-	if nested {
-		paths = _%sFieldPathsNested[:]
-	}
-	ret := make([]string, len(paths))
-	copy(ret, paths)
-	return ret
 }
 
 func (dst *%s) SetFields(src *%s, paths ...string) error {`,
@@ -570,9 +560,6 @@ func (dst *%s) SetFields(src *%s, paths ...string) error {`,
 	"`)+`",`,
 		mType, `"`+strings.Join(topLevelPaths, `",
 	"`)+`",`,
-		mType,
-		mType,
-		mType,
 		mType, mType,
 	)
 

--- a/main_test.go
+++ b/main_test.go
@@ -132,14 +132,14 @@ func TestGolden(t *testing.T) {
 
 func TestFieldMaskPaths(t *testing.T) {
 	a := assertions.New(t)
-	a.So(((*testdata.Test)(nil)).FieldMaskPaths(false), should.Resemble, []string{
+	a.So(testdata.TestFieldPathsTopLevel, should.Resemble, []string{
 		"a",
 		"b",
 		"c",
 		"g",
 		"testOneof",
 	})
-	a.So(((*testdata.Test)(nil)).FieldMaskPaths(true), should.Resemble, []string{
+	a.So(testdata.TestFieldPathsNested, should.Resemble, []string{
 		"a",
 		"a.a",
 		"a.a.a",

--- a/testdata/testdata.pb.fm.go
+++ b/testdata/testdata.pb.fm.go
@@ -18,7 +18,7 @@ func (dst *Empty) SetFields(src *Empty, paths ...string) error {
 	return nil
 }
 
-var _TestFieldPathsNested = [...]string{
+var TestFieldPathsNested = []string{
 	"a",
 	"a.a",
 	"a.a.a",
@@ -56,22 +56,12 @@ var _TestFieldPathsNested = [...]string{
 	"testOneof.f",
 }
 
-var _TestFieldPathsTopLevel = [...]string{
+var TestFieldPathsTopLevel = []string{
 	"a",
 	"b",
 	"c",
 	"g",
 	"testOneof",
-}
-
-func (*Test) FieldMaskPaths(nested bool) []string {
-	paths := _TestFieldPathsTopLevel[:]
-	if nested {
-		paths = _TestFieldPathsNested[:]
-	}
-	ret := make([]string, len(paths))
-	copy(ret, paths)
-	return ret
 }
 
 func (dst *Test) SetFields(src *Test, paths ...string) error {
@@ -226,7 +216,7 @@ func (dst *Test) SetFields(src *Test, paths ...string) error {
 	return nil
 }
 
-var _Test_TestNestedFieldPathsNested = [...]string{
+var Test_TestNestedFieldPathsNested = []string{
 	"a",
 	"a.a",
 	"a.b",
@@ -238,22 +228,12 @@ var _Test_TestNestedFieldPathsNested = [...]string{
 	"e",
 }
 
-var _Test_TestNestedFieldPathsTopLevel = [...]string{
+var Test_TestNestedFieldPathsTopLevel = []string{
 	"a",
 	"b",
 	"c",
 	"d",
 	"e",
-}
-
-func (*Test_TestNested) FieldMaskPaths(nested bool) []string {
-	paths := _Test_TestNestedFieldPathsTopLevel[:]
-	if nested {
-		paths = _Test_TestNestedFieldPathsNested[:]
-	}
-	ret := make([]string, len(paths))
-	copy(ret, paths)
-	return ret
 }
 
 func (dst *Test_TestNested) SetFields(src *Test_TestNested, paths ...string) error {
@@ -325,28 +305,18 @@ func (dst *Test_TestNested) SetFields(src *Test_TestNested, paths ...string) err
 	return nil
 }
 
-var _Test_TestNested_TestNestedNestedFieldPathsNested = [...]string{
+var Test_TestNested_TestNestedNestedFieldPathsNested = []string{
 	"a",
 	"b",
 	"c",
 	"d",
 }
 
-var _Test_TestNested_TestNestedNestedFieldPathsTopLevel = [...]string{
+var Test_TestNested_TestNestedNestedFieldPathsTopLevel = []string{
 	"a",
 	"b",
 	"c",
 	"d",
-}
-
-func (*Test_TestNested_TestNestedNested) FieldMaskPaths(nested bool) []string {
-	paths := _Test_TestNested_TestNestedNestedFieldPathsTopLevel[:]
-	if nested {
-		paths = _Test_TestNested_TestNestedNestedFieldPathsNested[:]
-	}
-	ret := make([]string, len(paths))
-	copy(ret, paths)
-	return ret
 }
 
 func (dst *Test_TestNested_TestNestedNested) SetFields(src *Test_TestNested_TestNestedNested, paths ...string) error {


### PR DESCRIPTION
**Summary:**
<!--
A summary, always referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #12 

<!--
Please motivate briefly why it is implemented this way, if that deviates
from the implementation proposal in the referenced issues.
-->

**Changes:**
<!-- What are the changes made in this pull request? -->

- Expose top level and nested field mask paths
- Remove method that copies and returns them