### PR TITLE
add benchmark and improve performance

### DIFF
--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -258,7 +258,7 @@ func BenchmarkSetFields(t *testing.B) {
 		t.Run(tc.Name, func(t *testing.B) {
 			t.ResetTimer()
 			for i := 0; i < t.N; i++ {
-				tc.Destination.ValidateFields(tc.Paths...)
+				// tc.Destination.ValidateFields(tc.Paths...)
 				tc.Destination.SetFields(tc.Source, tc.Paths...)
 			}
 		})

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -1,0 +1,266 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/TheThingsIndustries/protoc-gen-fieldmask/testdata"
+	"github.com/smartystreets/assertions"
+	"github.com/smartystreets/assertions/should"
+)
+
+func BenchmarkSetFields(t *testing.B) {
+	for _, tc := range []struct {
+		Name                        string
+		Source, Destination, Result *testdata.Test
+		Paths                       []string
+		ErrorAssertion              func(t *testing.T, err error) bool
+	}{
+		{
+			Name: "nil source",
+			Destination: &testdata.Test{
+				A: &testdata.Test_TestNested{},
+				CustomName: &testdata.Test_TestNested{
+					A: &testdata.Test_TestNested_TestNestedNested{},
+				},
+			},
+			Source: nil,
+			Paths:  []string{"a.b", "b.c"},
+			Result: &testdata.Test{
+				A: &testdata.Test_TestNested{},
+				CustomName: &testdata.Test_TestNested{
+					A: &testdata.Test_TestNested_TestNestedNested{},
+				},
+			},
+		},
+		{
+			Name: "no paths",
+			Destination: &testdata.Test{
+				CustomName: &testdata.Test_TestNested{
+					A: &testdata.Test_TestNested_TestNestedNested{},
+				},
+			},
+			Source: &testdata.Test{
+				A: &testdata.Test_TestNested{
+					B: []byte{1, 2, 3},
+				},
+				CustomName: &testdata.Test_TestNested{
+					B: []byte{1, 2, 4},
+				},
+			},
+			Paths: nil,
+			Result: &testdata.Test{
+				CustomName: &testdata.Test_TestNested{
+					A: &testdata.Test_TestNested_TestNestedNested{},
+				},
+			},
+		},
+		{
+			Name: "a.b",
+			Destination: &testdata.Test{
+				CustomName: &testdata.Test_TestNested{
+					A: &testdata.Test_TestNested_TestNestedNested{},
+				},
+			},
+			Source: &testdata.Test{
+				A: &testdata.Test_TestNested{
+					B: []byte{1, 2, 3},
+				},
+				CustomName: &testdata.Test_TestNested{
+					B: []byte{1, 2, 4},
+				},
+			},
+			Paths: []string{"a.b"},
+			Result: &testdata.Test{
+				A: &testdata.Test_TestNested{
+					B: []byte{1, 2, 3},
+				},
+				CustomName: &testdata.Test_TestNested{
+					A: &testdata.Test_TestNested_TestNestedNested{},
+				},
+			},
+		},
+		{
+			Name: "a.b,a.a.a,a.b,a.b,b,testOneof",
+			Destination: &testdata.Test{
+				TestOneof: &testdata.Test_CustomNameOneof{},
+				G:         &testdata.Empty{},
+			},
+			Source: &testdata.Test{
+				A: &testdata.Test_TestNested{
+					B: []byte{1, 2, 3},
+				},
+				CustomName: &testdata.Test_TestNested{
+					B: []byte{1, 2, 4},
+				},
+				TestOneof: &testdata.Test_D{
+					D: 42,
+				},
+			},
+			Paths: []string{"a.b", "a.a.a", "a.b", "a.b", "b", "testOneof"},
+			Result: &testdata.Test{
+				A: &testdata.Test_TestNested{
+					B: []byte{1, 2, 3},
+				},
+				CustomName: &testdata.Test_TestNested{
+					B: []byte{1, 2, 4},
+				},
+				TestOneof: &testdata.Test_D{
+					D: 42,
+				},
+				G: &testdata.Empty{},
+			},
+		},
+		{
+			Name: "destination testOneof mismatch",
+			Destination: &testdata.Test{
+				TestOneof: &testdata.Test_CustomNameOneof{
+					CustomNameOneof: 42,
+				},
+				G: &testdata.Empty{},
+			},
+			Source: &testdata.Test{
+				TestOneof: &testdata.Test_D{
+					D: 42,
+				},
+			},
+			Paths: []string{"testOneof.d"},
+			Result: &testdata.Test{
+				TestOneof: &testdata.Test_CustomNameOneof{
+					CustomNameOneof: 42,
+				},
+				G: &testdata.Empty{},
+			},
+			ErrorAssertion: func(t *testing.T, err error) bool { return assertions.New(t).So(err, should.BeError) },
+		},
+		{
+			Name: "source testOneof mismatch",
+			Destination: &testdata.Test{
+				TestOneof: &testdata.Test_D{
+					D: 42,
+				},
+				G: &testdata.Empty{},
+			},
+			Source: &testdata.Test{
+				TestOneof: &testdata.Test_CustomNameOneof{
+					CustomNameOneof: 42,
+				},
+			},
+			Paths: []string{"testOneof.d"},
+			Result: &testdata.Test{
+				TestOneof: &testdata.Test_D{
+					D: 42,
+				},
+				G: &testdata.Empty{},
+			},
+			ErrorAssertion: func(t *testing.T, err error) bool { return assertions.New(t).So(err, should.BeError) },
+		},
+		{
+			Name: "unset testOneof",
+			Destination: &testdata.Test{
+				TestOneof: &testdata.Test_D{
+					D: 42,
+				},
+				G: &testdata.Empty{},
+			},
+			Source: &testdata.Test{},
+			Paths:  []string{"testOneof.d"},
+			Result: &testdata.Test{
+				G: &testdata.Empty{},
+			},
+		},
+		{
+			Name: "set non-existing testOneof",
+			Destination: &testdata.Test{
+				G: &testdata.Empty{},
+			},
+			Source: &testdata.Test{},
+			Paths:  []string{"testOneof.e"},
+			Result: &testdata.Test{
+				G: &testdata.Empty{},
+			},
+		},
+		{
+			Name:        "testOneof.k.a.a",
+			Destination: &testdata.Test{},
+			Source: &testdata.Test{
+				TestOneof: &testdata.Test_K{
+					K: &testdata.Test_TestNested{
+						A: &testdata.Test_TestNested_TestNestedNested{
+							A: 42,
+						},
+					},
+				},
+			},
+			Paths: []string{"testOneof.k.a.a"},
+			Result: &testdata.Test{
+				TestOneof: &testdata.Test_K{
+					K: &testdata.Test_TestNested{
+						A: &testdata.Test_TestNested_TestNestedNested{
+							A: 42,
+						},
+					},
+				},
+			},
+		},
+		{
+			Name: "non-nullable c.a",
+			Destination: &testdata.Test{
+				C: testdata.Test_TestNested{
+					A: &testdata.Test_TestNested_TestNestedNested{},
+				},
+			},
+			Source: &testdata.Test{
+				C: testdata.Test_TestNested{
+					B: []byte("42"),
+				},
+			},
+			Paths: []string{"c.b"},
+			Result: &testdata.Test{
+				C: testdata.Test_TestNested{
+					A: &testdata.Test_TestNested_TestNestedNested{},
+					B: []byte("42"),
+				},
+			},
+		},
+		{
+			Name:           "non-existent top-level field",
+			Destination:    &testdata.Test{},
+			Source:         &testdata.Test{},
+			Paths:          []string{"42"},
+			Result:         &testdata.Test{},
+			ErrorAssertion: func(t *testing.T, err error) bool { return assertions.New(t).So(err, should.BeError) },
+		},
+		{
+			Name:           "non-existent sub-field",
+			Destination:    &testdata.Test{},
+			Source:         &testdata.Test{},
+			Paths:          []string{"41.42.43"},
+			Result:         &testdata.Test{},
+			ErrorAssertion: func(t *testing.T, err error) bool { return assertions.New(t).So(err, should.BeError) },
+		},
+		{
+			Name:           "non-existent oneof",
+			Destination:    &testdata.Test{},
+			Source:         &testdata.Test{},
+			Paths:          []string{"testOneof.42"},
+			Result:         &testdata.Test{},
+			ErrorAssertion: func(t *testing.T, err error) bool { return assertions.New(t).So(err, should.BeError) },
+		},
+		{
+			Name:           "double oneofs",
+			Destination:    &testdata.Test{},
+			Source:         &testdata.Test{},
+			Paths:          []string{"testOneof.e", "testOneof.d"},
+			Result:         &testdata.Test{},
+			ErrorAssertion: func(t *testing.T, err error) bool { return assertions.New(t).So(err, should.BeError) },
+		},
+	} {
+		t.Run(tc.Name, func(t *testing.B) {
+			t.ResetTimer()
+			for i := 0; i < t.N; i++ {
+				tc.Destination.ValidateFields(tc.Paths...)
+				tc.Destination.SetFields(tc.Source, tc.Paths...)
+			}
+		})
+	}
+}

--- a/main_test.go
+++ b/main_test.go
@@ -336,6 +336,34 @@ func TestSetFields(t *testing.T) {
 			},
 		},
 		{
+			Name: "a",
+			Destination: &testdata.Test{
+				CustomName: &testdata.Test_TestNested{
+					A: &testdata.Test_TestNested_TestNestedNested{},
+				},
+			},
+			Source: &testdata.Test{
+				A: &testdata.Test_TestNested{
+					A: &testdata.Test_TestNested_TestNestedNested{
+						B: 42,
+					},
+					B: []byte{1, 2, 3},
+				},
+			},
+			Paths: []string{"a"},
+			Result: &testdata.Test{
+				A: &testdata.Test_TestNested{
+					A: &testdata.Test_TestNested_TestNestedNested{
+						B: 42,
+					},
+					B: []byte{1, 2, 3},
+				},
+				CustomName: &testdata.Test_TestNested{
+					A: &testdata.Test_TestNested_TestNestedNested{},
+				},
+			},
+		},
+		{
 			Name: "a.b",
 			Destination: &testdata.Test{
 				CustomName: &testdata.Test_TestNested{
@@ -353,6 +381,62 @@ func TestSetFields(t *testing.T) {
 			Paths: []string{"a.b"},
 			Result: &testdata.Test{
 				A: &testdata.Test_TestNested{
+					B: []byte{1, 2, 3},
+				},
+				CustomName: &testdata.Test_TestNested{
+					A: &testdata.Test_TestNested_TestNestedNested{},
+				},
+			},
+		},
+		{
+			Name: "a,a.b",
+			Destination: &testdata.Test{
+				CustomName: &testdata.Test_TestNested{
+					A: &testdata.Test_TestNested_TestNestedNested{},
+				},
+			},
+			Source: &testdata.Test{
+				A: &testdata.Test_TestNested{
+					A: &testdata.Test_TestNested_TestNestedNested{
+						B: 42,
+					},
+					B: []byte{1, 2, 3},
+				},
+			},
+			Paths: []string{"a", "a.b"},
+			Result: &testdata.Test{
+				A: &testdata.Test_TestNested{
+					A: &testdata.Test_TestNested_TestNestedNested{
+						B: 42,
+					},
+					B: []byte{1, 2, 3},
+				},
+				CustomName: &testdata.Test_TestNested{
+					A: &testdata.Test_TestNested_TestNestedNested{},
+				},
+			},
+		},
+		{
+			Name: "a.b,a",
+			Destination: &testdata.Test{
+				CustomName: &testdata.Test_TestNested{
+					A: &testdata.Test_TestNested_TestNestedNested{},
+				},
+			},
+			Source: &testdata.Test{
+				A: &testdata.Test_TestNested{
+					A: &testdata.Test_TestNested_TestNestedNested{
+						B: 42,
+					},
+					B: []byte{1, 2, 3},
+				},
+			},
+			Paths: []string{"a.b", "a"},
+			Result: &testdata.Test{
+				A: &testdata.Test_TestNested{
+					A: &testdata.Test_TestNested_TestNestedNested{
+						B: 42,
+					},
 					B: []byte{1, 2, 3},
 				},
 				CustomName: &testdata.Test_TestNested{

--- a/module/path_helper.go
+++ b/module/path_helper.go
@@ -195,7 +195,10 @@ func _processPaths(paths []string) map[string][]string {
 		}
 		parts := strings.SplitN(p, ".", 2)
 		h, t := parts[0], parts[1]
-		if _, ok := pathMap[h]; ok {
+		if val, ok := pathMap[h]; ok {
+			if val == nil {
+				continue
+			}
 			pathMap[h] = append(pathMap[h], t)
 		} else {
 			pathMap[h] = []string{t}

--- a/module/path_helper.go
+++ b/module/path_helper.go
@@ -179,41 +179,29 @@ func (m *pathHelperModule) Execute(files map[string]pgs.File, pkgs map[string]pg
 		m.AddGeneratorTemplateFile(dir.Push(dir.Base()).SetExt(".pb.util.fm.go").String(), template.Must(template.New("util").Parse(`package {{ .Package }}
 
 import (
-	"sort"
 	"strings"
 )
 
 // _processPaths returns paths as a pathMap.
 func _processPaths(paths []string) map[string][]string {
-	sort.Strings(paths)
-
-	topLevel := make(map[string]struct{}, len(paths))
-	_pathMap := make(map[string]map[string]struct{}, len(paths))
+	if len(paths) == 0 {
+		return nil
+	}
+	pathMap := make(map[string][]string, len(paths))
 	for _, p := range paths {
 		if !strings.Contains(p, ".") {
-			topLevel[p] = struct{}{}
+			pathMap[p] = nil
 			continue
 		}
 		parts := strings.SplitN(p, ".", 2)
 		h, t := parts[0], parts[1]
-		if _pathMap[h] == nil {
-			_pathMap[h] = map[string]struct{}{t: {}}
+		if _, ok := pathMap[h]; ok {
+			pathMap[h] = append(pathMap[h], t)
 		} else {
-			_pathMap[h][t] = struct{}{}
+			pathMap[h] = []string{t}
 		}
 	}
 
-	for f := range topLevel {
-		_pathMap[f] = nil
-	}
-
-	pathMap := make(map[string][]string, len(_pathMap))
-	for top, subs := range _pathMap {
-		pathMap[top] = make([]string, 0, len(subs))
-		for sub := range subs {
-			pathMap[top] = append(pathMap[top], sub)
-		}
-	}
 	return pathMap
 }`)), struct {
 			Package pgs.Name

--- a/module/setter.go
+++ b/module/setter.go
@@ -216,7 +216,7 @@ func (dst *%s) SetFields(src *%s, paths ...string) error {
 
 	fmt.Fprintf(buf, `
 func (dst *%s) SetFields(src *%s, paths ...string) error {
-	for name, subs := range _processPaths(append(paths[:0:0], paths...)) {
+	for name, subs := range _processPaths(paths) {
 		switch name {
 `,
 		mType, mType,

--- a/testdata/testdata.pb.setters.fm.go
+++ b/testdata/testdata.pb.setters.fm.go
@@ -19,7 +19,7 @@ func (dst *Empty) SetFields(src *Empty, paths ...string) error {
 }
 
 func (dst *Test) SetFields(src *Test, paths ...string) error {
-	for name, subs := range _processPaths(append(paths[:0:0], paths...)) {
+	for name, subs := range _processPaths(paths) {
 		switch name {
 		case "a":
 			if len(subs) > 0 {
@@ -247,7 +247,7 @@ func (dst *Test) SetFields(src *Test, paths ...string) error {
 }
 
 func (dst *Test_TestNested) SetFields(src *Test_TestNested, paths ...string) error {
-	for name, subs := range _processPaths(append(paths[:0:0], paths...)) {
+	for name, subs := range _processPaths(paths) {
 		switch name {
 		case "a":
 			if len(subs) > 0 {
@@ -338,7 +338,7 @@ func (dst *Test_TestNested) SetFields(src *Test_TestNested, paths ...string) err
 }
 
 func (dst *Test_TestNested_TestNestedNested) SetFields(src *Test_TestNested_TestNestedNested, paths ...string) error {
-	for name, subs := range _processPaths(append(paths[:0:0], paths...)) {
+	for name, subs := range _processPaths(paths) {
 		switch name {
 		case "a":
 			if len(subs) > 0 {
@@ -518,7 +518,7 @@ func (dst *Test_TestNested_TestNestedNested) SetFields(src *Test_TestNested_Test
 }
 
 func (dst *Test_TestNested_TestNestedNested_TestNestedNestedEmbed) SetFields(src *Test_TestNested_TestNestedNested_TestNestedNestedEmbed, paths ...string) error {
-	for name, subs := range _processPaths(append(paths[:0:0], paths...)) {
+	for name, subs := range _processPaths(paths) {
 		switch name {
 		case "nested_field":
 			if len(subs) > 0 {
@@ -539,7 +539,7 @@ func (dst *Test_TestNested_TestNestedNested_TestNestedNestedEmbed) SetFields(src
 }
 
 func (dst *Test_TestNested_TestNestedNested_TestNestedNestedEmbed2) SetFields(src *Test_TestNested_TestNestedNested_TestNestedNestedEmbed2, paths ...string) error {
-	for name, subs := range _processPaths(append(paths[:0:0], paths...)) {
+	for name, subs := range _processPaths(paths) {
 		switch name {
 		case "nested_field_2":
 			if len(subs) > 0 {

--- a/testdata/testdata.pb.util.fm.go
+++ b/testdata/testdata.pb.util.fm.go
@@ -3,40 +3,28 @@
 package testdata
 
 import (
-	"sort"
 	"strings"
 )
 
 // _processPaths returns paths as a pathMap.
 func _processPaths(paths []string) map[string][]string {
-	sort.Strings(paths)
-
-	topLevel := make(map[string]struct{}, len(paths))
-	_pathMap := make(map[string]map[string]struct{}, len(paths))
+	if len(paths) == 0 {
+		return nil
+	}
+	pathMap := make(map[string][]string, len(paths))
 	for _, p := range paths {
 		if !strings.Contains(p, ".") {
-			topLevel[p] = struct{}{}
+			pathMap[p] = nil
 			continue
 		}
 		parts := strings.SplitN(p, ".", 2)
 		h, t := parts[0], parts[1]
-		if _pathMap[h] == nil {
-			_pathMap[h] = map[string]struct{}{t: {}}
+		if _, ok := pathMap[h]; ok {
+			pathMap[h] = append(pathMap[h], t)
 		} else {
-			_pathMap[h][t] = struct{}{}
+			pathMap[h] = []string{t}
 		}
 	}
 
-	for f := range topLevel {
-		_pathMap[f] = nil
-	}
-
-	pathMap := make(map[string][]string, len(_pathMap))
-	for top, subs := range _pathMap {
-		pathMap[top] = make([]string, 0, len(subs))
-		for sub := range subs {
-			pathMap[top] = append(pathMap[top], sub)
-		}
-	}
 	return pathMap
 }

--- a/testdata/testdata.pb.util.fm.go
+++ b/testdata/testdata.pb.util.fm.go
@@ -19,7 +19,10 @@ func _processPaths(paths []string) map[string][]string {
 		}
 		parts := strings.SplitN(p, ".", 2)
 		h, t := parts[0], parts[1]
-		if _, ok := pathMap[h]; ok {
+		if val, ok := pathMap[h]; ok {
+			if val == nil {
+				continue
+			}
 			pathMap[h] = append(pathMap[h], t)
 		} else {
 			pathMap[h] = []string{t}


### PR DESCRIPTION
#### Summary
Performance need improvement.

#### Changes
- add benchmark test
- simplify the logic of _processPaths to improve performance

#### Notes for Reviewers
benchmark before
```
Running tool: /usr/local/opt/go/libexec/bin/go test -benchmem -run=^$ github.com/TheThingsIndustries/protoc-gen-fieldmask -bench ^(BenchmarkSetFields)$

goos: darwin
goarch: amd64
pkg: github.com/TheThingsIndustries/protoc-gen-fieldmask
BenchmarkSetFields/nil_source-4         	  436851	      3307 ns/op	    1840 B/op	      20 allocs/op
BenchmarkSetFields/no_paths-4           	 7820179	       184 ns/op	      48 B/op	       1 allocs/op
BenchmarkSetFields/a.b-4                	  690620	      1959 ns/op	    1136 B/op	      12 allocs/op
BenchmarkSetFields/a.b,a.a.a,a.b,a.b,b,testOneof-4         	  349719	      3961 ns/op	    1584 B/op	      19 allocs/op
BenchmarkSetFields/destination_testOneof_mismatch-4        	  544834	      2126 ns/op	    1216 B/op	      13 allocs/op
BenchmarkSetFields/source_testOneof_mismatch-4             	  569792	      2531 ns/op	    1200 B/op	      13 allocs/op
BenchmarkSetFields/unset_testOneof-4                       	  693373	      1856 ns/op	    1120 B/op	      11 allocs/op
BenchmarkSetFields/set_non-existing_testOneof-4            	  718399	      1932 ns/op	    1120 B/op	      11 allocs/op
BenchmarkSetFields/testOneof.k.a.a-4                       	  310720	      4273 ns/op	    2496 B/op	      27 allocs/op
BenchmarkSetFields/non-nullable_c.a-4                      	  559153	      2054 ns/op	    1136 B/op	      12 allocs/op
BenchmarkSetFields/non-existent_top-level_field-4          	  795229	      1372 ns/op	     512 B/op	       7 allocs/op
BenchmarkSetFields/non-existent_sub-field-4                	  666229	      1767 ns/op	     752 B/op	      11 allocs/op
BenchmarkSetFields/non-existent_oneof-4                    	  622804	      2440 ns/op	    1216 B/op	      15 allocs/op
BenchmarkSetFields/double_oneofs-4                         	  472322	      3343 ns/op	    1280 B/op	      15 allocs/op
PASS
ok  	github.com/TheThingsIndustries/protoc-gen-fieldmask	21.144s
Success: Benchmarks passed.

```

benchmark after
```
Running tool: /usr/local/opt/go/libexec/bin/go test -benchmem -run=^$ github.com/TheThingsIndustries/protoc-gen-fieldmask -bench ^(BenchmarkSetFields)$

goos: darwin
goarch: amd64
pkg: github.com/TheThingsIndustries/protoc-gen-fieldmask
BenchmarkSetFields/nil_source-4         	  634264	      1922 ns/op	    1360 B/op	      13 allocs/op
BenchmarkSetFields/no_paths-4           	70568052	        17.7 ns/op	       0 B/op	       0 allocs/op
BenchmarkSetFields/a.b-4                	 1000000	      1098 ns/op	     880 B/op	       8 allocs/op
BenchmarkSetFields/a.b,a.a.a,a.b,a.b,b,testOneof-4         	  554421	      2980 ns/op	    1248 B/op	      15 allocs/op
BenchmarkSetFields/destination_testOneof_mismatch-4        	 1000000	      1359 ns/op	     960 B/op	       9 allocs/op
BenchmarkSetFields/source_testOneof_mismatch-4             	  828547	      1309 ns/op	     944 B/op	       9 allocs/op
BenchmarkSetFields/unset_testOneof-4                       	 1000000	      1004 ns/op	     864 B/op	       7 allocs/op
BenchmarkSetFields/set_non-existing_testOneof-4            	 1000000	      1028 ns/op	     864 B/op	       7 allocs/op
BenchmarkSetFields/testOneof.k.a.a-4                       	  557286	      2808 ns/op	    1792 B/op	      17 allocs/op
BenchmarkSetFields/non-nullable_c.a-4                      	 1000000	      1186 ns/op	     880 B/op	       8 allocs/op
BenchmarkSetFields/non-existent_top-level_field-4          	 1696417	       769 ns/op	     480 B/op	       6 allocs/op
BenchmarkSetFields/non-existent_sub-field-4                	 1000000	      1167 ns/op	     528 B/op	       8 allocs/op
BenchmarkSetFields/non-existent_oneof-4                    	  892474	      1960 ns/op	     960 B/op	      11 allocs/op
BenchmarkSetFields/double_oneofs-4                         	  738782	      1792 ns/op	    1040 B/op	      12 allocs/op
PASS
ok  	github.com/TheThingsIndustries/protoc-gen-fieldmask	19.506s
Success: Benchmarks passed.
```
#### Release Notes

