### PR TITLE
Relax oneof set fields validation

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: '~1.15'
+        go-version: '~1.17'
     - name: Initialize Go module cache
       uses: actions/cache@v2
       with:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/TheThingsIndustries/protoc-gen-fieldmask
 
-go 1.15
+go 1.17
 
 replace github.com/lyft/protoc-gen-star => github.com/TheThingsIndustries/protoc-gen-star v0.5.2-gogo.1
 
@@ -16,4 +16,15 @@ require (
 	github.com/lyft/protoc-gen-star v0.5.2
 	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826
 	github.com/smartystreets/assertions v1.0.1
+)
+
+require (
+	github.com/iancoleman/strcase v0.1.2 // indirect
+	github.com/kr/text v0.1.0 // indirect
+	github.com/spf13/afero v1.4.1 // indirect
+	golang.org/x/lint v0.0.0-20200302205851-738671d3881b // indirect
+	golang.org/x/mod v0.3.0 // indirect
+	golang.org/x/text v0.3.3 // indirect
+	golang.org/x/tools v0.0.0-20210106214847-113979e3529a // indirect
+	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -73,7 +73,6 @@ golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=

--- a/main_test.go
+++ b/main_test.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/TheThingsIndustries/protoc-gen-fieldmask/testdata"
+	"github.com/gogo/protobuf/types"
 	"github.com/kr/pretty"
 	"github.com/mohae/deepcopy"
 	"github.com/smartystreets/assertions"
@@ -490,12 +491,29 @@ var setFieldsTestCases = []struct {
 		},
 		Paths: []string{"testOneof.d"},
 		Result: &testdata.Test{
-			TestOneof: &testdata.Test_CustomNameOneof{
-				CustomNameOneof: 42,
+			TestOneof: &testdata.Test_D{
+				D: 42,
 			},
 			G: &testdata.Empty{},
 		},
-		ErrorAssertion: func(t *testing.T, err error) bool { return assertions.New(t).So(err, should.BeError) },
+	},
+	{
+		Name: "destination testOneof empty",
+		Destination: &testdata.Test{
+			G: &testdata.Empty{},
+		},
+		Source: &testdata.Test{
+			TestOneof: &testdata.Test_D{
+				D: 42,
+			},
+		},
+		Paths: []string{"testOneof.d"},
+		Result: &testdata.Test{
+			TestOneof: &testdata.Test_D{
+				D: 42,
+			},
+			G: &testdata.Empty{},
+		},
 	},
 	{
 		Name: "source testOneof mismatch",
@@ -512,12 +530,48 @@ var setFieldsTestCases = []struct {
 		},
 		Paths: []string{"testOneof.d"},
 		Result: &testdata.Test{
-			TestOneof: &testdata.Test_D{
-				D: 42,
+			G: &testdata.Empty{},
+		},
+	},
+	{
+		Name: "source testOneof empty",
+		Destination: &testdata.Test{
+			G: &testdata.Empty{},
+		},
+		Source: &testdata.Test{},
+		Paths:  []string{"testOneof.d"},
+		Result: &testdata.Test{
+			G: &testdata.Empty{},
+		},
+	},
+	{
+		Name: "source+destination testOneof mismatch",
+		Destination: &testdata.Test{
+			TestOneof: &testdata.Test_F{
+				F: []byte{0x42},
 			},
 			G: &testdata.Empty{},
 		},
-		ErrorAssertion: func(t *testing.T, err error) bool { return assertions.New(t).So(err, should.BeError) },
+		Source: &testdata.Test{
+			TestOneof: &testdata.Test_CustomNameOneof{
+				CustomNameOneof: 42,
+			},
+		},
+		Paths: []string{"testOneof.d"},
+		Result: &testdata.Test{
+			G: &testdata.Empty{},
+		},
+	},
+	{
+		Name: "source+destination testOneof empty",
+		Destination: &testdata.Test{
+			G: &testdata.Empty{},
+		},
+		Source: &testdata.Test{},
+		Paths:  []string{"testOneof.d"},
+		Result: &testdata.Test{
+			G: &testdata.Empty{},
+		},
 	},
 	{
 		Name: "unset testOneof",
@@ -563,6 +617,184 @@ var setFieldsTestCases = []struct {
 					A: &testdata.Test_TestNested_TestNestedNested{
 						A: 42,
 					},
+				},
+			},
+		},
+	},
+	{
+		Name:        "source testOneof.k.a.testNestedNestedOneOf.g mismatch",
+		Destination: &testdata.Test{},
+		Source: &testdata.Test{
+			TestOneof: &testdata.Test_K{
+				K: &testdata.Test_TestNested{
+					A: &testdata.Test_TestNested_TestNestedNested{
+						TestNestedNestedOneOf: &testdata.Test_TestNested_TestNestedNested_F{
+							F: 42,
+						},
+					},
+				},
+			},
+		},
+		Paths: []string{"testOneof.k.a.testNestedNestedOneOf.g"},
+		Result: &testdata.Test{
+			TestOneof: &testdata.Test_K{
+				K: &testdata.Test_TestNested{
+					A: &testdata.Test_TestNested_TestNestedNested{},
+				},
+			},
+		},
+	},
+	{
+		Name:        "source testOneof.k.a.testNestedNestedOneOf.g empty",
+		Destination: &testdata.Test{},
+		Source: &testdata.Test{
+			TestOneof: &testdata.Test_K{
+				K: &testdata.Test_TestNested{
+					A: &testdata.Test_TestNested_TestNestedNested{},
+				},
+			},
+		},
+		Paths: []string{"testOneof.k.a.testNestedNestedOneOf.g"},
+		Result: &testdata.Test{
+			TestOneof: &testdata.Test_K{
+				K: &testdata.Test_TestNested{
+					A: &testdata.Test_TestNested_TestNestedNested{},
+				},
+			},
+		},
+	},
+	{
+		Name: "destination testOneof.k.a.testNestedNestedOneOf.g mismatch",
+		Destination: &testdata.Test{
+			TestOneof: &testdata.Test_K{
+				K: &testdata.Test_TestNested{
+					A: &testdata.Test_TestNested_TestNestedNested{
+						TestNestedNestedOneOf: &testdata.Test_TestNested_TestNestedNested_F{
+							F: 42,
+						},
+					},
+				},
+			},
+		},
+		Source: &testdata.Test{
+			TestOneof: &testdata.Test_K{
+				K: &testdata.Test_TestNested{
+					A: &testdata.Test_TestNested_TestNestedNested{
+						TestNestedNestedOneOf: &testdata.Test_TestNested_TestNestedNested_G{
+							G: &types.UInt64Value{
+								Value: 42,
+							},
+						},
+					},
+				},
+			},
+		},
+		Paths: []string{"testOneof.k.a.testNestedNestedOneOf.g"},
+		Result: &testdata.Test{
+			TestOneof: &testdata.Test_K{
+				K: &testdata.Test_TestNested{
+					A: &testdata.Test_TestNested_TestNestedNested{
+						TestNestedNestedOneOf: &testdata.Test_TestNested_TestNestedNested_G{
+							G: &types.UInt64Value{
+								Value: 42,
+							},
+						},
+					},
+				},
+			},
+		},
+	},
+	{
+		Name: "destination testOneof.k.a.testNestedNestedOneOf.g empty",
+		Destination: &testdata.Test{
+			TestOneof: &testdata.Test_K{
+				K: &testdata.Test_TestNested{
+					A: &testdata.Test_TestNested_TestNestedNested{},
+				},
+			},
+		},
+		Source: &testdata.Test{
+			TestOneof: &testdata.Test_K{
+				K: &testdata.Test_TestNested{
+					A: &testdata.Test_TestNested_TestNestedNested{
+						TestNestedNestedOneOf: &testdata.Test_TestNested_TestNestedNested_G{
+							G: &types.UInt64Value{
+								Value: 42,
+							},
+						},
+					},
+				},
+			},
+		},
+		Paths: []string{"testOneof.k.a.testNestedNestedOneOf.g"},
+		Result: &testdata.Test{
+			TestOneof: &testdata.Test_K{
+				K: &testdata.Test_TestNested{
+					A: &testdata.Test_TestNested_TestNestedNested{
+						TestNestedNestedOneOf: &testdata.Test_TestNested_TestNestedNested_G{
+							G: &types.UInt64Value{
+								Value: 42,
+							},
+						},
+					},
+				},
+			},
+		},
+	},
+	{
+		Name: "source+destination testOneof.k.a.testNestedNestedOneOf.g mismatch",
+		Destination: &testdata.Test{
+			TestOneof: &testdata.Test_K{
+				K: &testdata.Test_TestNested{
+					A: &testdata.Test_TestNested_TestNestedNested{
+						TestNestedNestedOneOf: &testdata.Test_TestNested_TestNestedNested_F{
+							F: 42,
+						},
+					},
+				},
+			},
+		},
+		Source: &testdata.Test{
+			TestOneof: &testdata.Test_K{
+				K: &testdata.Test_TestNested{
+					A: &testdata.Test_TestNested_TestNestedNested{
+						TestNestedNestedOneOf: &testdata.Test_TestNested_TestNestedNested_E{
+							E: &testdata.Empty{},
+						},
+					},
+				},
+			},
+		},
+		Paths: []string{"testOneof.k.a.testNestedNestedOneOf.g"},
+		Result: &testdata.Test{
+			TestOneof: &testdata.Test_K{
+				K: &testdata.Test_TestNested{
+					A: &testdata.Test_TestNested_TestNestedNested{},
+				},
+			},
+		},
+	},
+	{
+		Name: "source+destination testOneof.k.a.testNestedNestedOneOf.g empty",
+		Destination: &testdata.Test{
+			TestOneof: &testdata.Test_K{
+				K: &testdata.Test_TestNested{
+					A: &testdata.Test_TestNested_TestNestedNested{},
+				},
+			},
+		},
+		Source: &testdata.Test{
+			TestOneof: &testdata.Test_K{
+				K: &testdata.Test_TestNested{
+					A: &testdata.Test_TestNested_TestNestedNested{},
+				},
+			},
+		},
+		Paths: []string{"testOneof.k.a.testNestedNestedOneOf.g"},
+		Result: &testdata.Test{
+			TestOneof: &testdata.Test_K{
+				K: &testdata.Test_TestNested{
+					A: &testdata.Test_TestNested_TestNestedNested{},
 				},
 			},
 		},

--- a/main_test.go
+++ b/main_test.go
@@ -645,6 +645,30 @@ var setFieldsTestCases = []struct {
 		},
 	},
 	{
+		Name:        "source testOneof.k.a.testNestedNestedOneOf.g.a mismatch",
+		Destination: &testdata.Test{},
+		Source: &testdata.Test{
+			TestOneof: &testdata.Test_K{
+				K: &testdata.Test_TestNested{
+					A: &testdata.Test_TestNested_TestNestedNested{
+						TestNestedNestedOneOf: &testdata.Test_TestNested_TestNestedNested_F{
+							F: 42,
+						},
+					},
+				},
+			},
+		},
+		Paths:          []string{"testOneof.k.a.testNestedNestedOneOf.g.a"},
+		ErrorAssertion: func(t *testing.T, err error) bool { return assertions.New(t).So(err, should.BeError) },
+		Result: &testdata.Test{
+			TestOneof: &testdata.Test_K{
+				K: &testdata.Test_TestNested{
+					A: &testdata.Test_TestNested_TestNestedNested{},
+				},
+			},
+		},
+	},
+	{
 		Name:        "source testOneof.k.a.testNestedNestedOneOf.g empty",
 		Destination: &testdata.Test{},
 		Source: &testdata.Test{
@@ -698,6 +722,46 @@ var setFieldsTestCases = []struct {
 							G: &types.UInt64Value{
 								Value: 42,
 							},
+						},
+					},
+				},
+			},
+		},
+	},
+	{
+		Name: "destination testOneof.k.a.testNestedNestedOneOf.g.a mismatch",
+		Destination: &testdata.Test{
+			TestOneof: &testdata.Test_K{
+				K: &testdata.Test_TestNested{
+					A: &testdata.Test_TestNested_TestNestedNested{
+						TestNestedNestedOneOf: &testdata.Test_TestNested_TestNestedNested_F{
+							F: 42,
+						},
+					},
+				},
+			},
+		},
+		Source: &testdata.Test{
+			TestOneof: &testdata.Test_K{
+				K: &testdata.Test_TestNested{
+					A: &testdata.Test_TestNested_TestNestedNested{
+						TestNestedNestedOneOf: &testdata.Test_TestNested_TestNestedNested_G{
+							G: &types.UInt64Value{
+								Value: 42,
+							},
+						},
+					},
+				},
+			},
+		},
+		Paths:          []string{"testOneof.k.a.testNestedNestedOneOf.g.a"},
+		ErrorAssertion: func(t *testing.T, err error) bool { return assertions.New(t).So(err, should.BeError) },
+		Result: &testdata.Test{
+			TestOneof: &testdata.Test_K{
+				K: &testdata.Test_TestNested{
+					A: &testdata.Test_TestNested_TestNestedNested{
+						TestNestedNestedOneOf: &testdata.Test_TestNested_TestNestedNested_F{
+							F: 42,
 						},
 					},
 				},

--- a/module/setter.go
+++ b/module/setter.go
@@ -36,7 +36,10 @@ func (m *setterModule) buildSetFieldsCase(buf *strings.Builder, imports importMa
 	buildIndented(buf, tabCount, fmt.Sprintf(`case "%s":`, f.Name()))
 
 	if f.InOneOf() {
-		buildIndented(buf, tabCount+1, fmt.Sprintf(`_, srcOk := src.%s.(*%s)`,
+		buildIndented(buf, tabCount+1, fmt.Sprintf(`var srcOk bool
+		if src != nil {
+			_, srcOk = src.%s.(*%s)
+		}`,
 			m.ctx.Name(f.OneOf()), m.ctx.OneofOption(f),
 		))
 	}
@@ -125,7 +128,10 @@ func (m *setterModule) buildSetFieldsCase(buf *strings.Builder, imports importMa
 		buildIndented(buf, tabCount+2, fmt.Sprintf(`if srcOk {
 	newSrc = src.%s
 }
-_, dstOk := dst.%s.(*%s)
+var dstOk bool
+if dst != nil {
+	_, dstOk = dst.%s.(*%s)
+}
 if dstOk {
 	newDst = dst.%s
 } else if srcOk {

--- a/testdata/testdata.pb.setters.fm.go
+++ b/testdata/testdata.pb.setters.fm.go
@@ -169,7 +169,10 @@ func (dst *Test) SetFields(src *Test, paths ...string) error {
 			for oneofName, oneofSubs := range subPathMap {
 				switch oneofName {
 				case "d":
-					_, srcOk := src.TestOneof.(*Test_D)
+					var srcOk bool
+					if src != nil {
+						_, srcOk = src.TestOneof.(*Test_D)
+					}
 					if len(oneofSubs) > 0 {
 						return fmt.Errorf("'d' has no subfields, but %s were specified", oneofSubs)
 					}
@@ -179,7 +182,10 @@ func (dst *Test) SetFields(src *Test, paths ...string) error {
 						dst.TestOneof = nil
 					}
 				case "e":
-					_, srcOk := src.TestOneof.(*Test_CustomNameOneof)
+					var srcOk bool
+					if src != nil {
+						_, srcOk = src.TestOneof.(*Test_CustomNameOneof)
+					}
 					if len(oneofSubs) > 0 {
 						return fmt.Errorf("'e' has no subfields, but %s were specified", oneofSubs)
 					}
@@ -189,7 +195,10 @@ func (dst *Test) SetFields(src *Test, paths ...string) error {
 						dst.TestOneof = nil
 					}
 				case "f":
-					_, srcOk := src.TestOneof.(*Test_F)
+					var srcOk bool
+					if src != nil {
+						_, srcOk = src.TestOneof.(*Test_F)
+					}
 					if len(oneofSubs) > 0 {
 						return fmt.Errorf("'f' has no subfields, but %s were specified", oneofSubs)
 					}
@@ -199,13 +208,19 @@ func (dst *Test) SetFields(src *Test, paths ...string) error {
 						dst.TestOneof = nil
 					}
 				case "k":
-					_, srcOk := src.TestOneof.(*Test_K)
+					var srcOk bool
+					if src != nil {
+						_, srcOk = src.TestOneof.(*Test_K)
+					}
 					if len(oneofSubs) > 0 {
 						var newDst, newSrc *Test_TestNested
 						if srcOk {
 							newSrc = src.TestOneof.(*Test_K).K
 						}
-						_, dstOk := dst.TestOneof.(*Test_K)
+						var dstOk bool
+						if dst != nil {
+							_, dstOk = dst.TestOneof.(*Test_K)
+						}
 						if dstOk {
 							newDst = dst.TestOneof.(*Test_K).K
 						} else if srcOk {
@@ -430,13 +445,19 @@ func (dst *Test_TestNested_TestNestedNested) SetFields(src *Test_TestNested_Test
 			for oneofName, oneofSubs := range subPathMap {
 				switch oneofName {
 				case "e":
-					_, srcOk := src.TestNestedNestedOneOf.(*Test_TestNested_TestNestedNested_E)
+					var srcOk bool
+					if src != nil {
+						_, srcOk = src.TestNestedNestedOneOf.(*Test_TestNested_TestNestedNested_E)
+					}
 					if len(oneofSubs) > 0 {
 						var newDst, newSrc *Empty
 						if srcOk {
 							newSrc = src.TestNestedNestedOneOf.(*Test_TestNested_TestNestedNested_E).E
 						}
-						_, dstOk := dst.TestNestedNestedOneOf.(*Test_TestNested_TestNestedNested_E)
+						var dstOk bool
+						if dst != nil {
+							_, dstOk = dst.TestNestedNestedOneOf.(*Test_TestNested_TestNestedNested_E)
+						}
 						if dstOk {
 							newDst = dst.TestNestedNestedOneOf.(*Test_TestNested_TestNestedNested_E).E
 						} else if srcOk {
@@ -457,7 +478,10 @@ func (dst *Test_TestNested_TestNestedNested) SetFields(src *Test_TestNested_Test
 						}
 					}
 				case "f":
-					_, srcOk := src.TestNestedNestedOneOf.(*Test_TestNested_TestNestedNested_F)
+					var srcOk bool
+					if src != nil {
+						_, srcOk = src.TestNestedNestedOneOf.(*Test_TestNested_TestNestedNested_F)
+					}
 					if len(oneofSubs) > 0 {
 						return fmt.Errorf("'f' has no subfields, but %s were specified", oneofSubs)
 					}
@@ -467,7 +491,10 @@ func (dst *Test_TestNested_TestNestedNested) SetFields(src *Test_TestNested_Test
 						dst.TestNestedNestedOneOf = nil
 					}
 				case "g":
-					_, srcOk := src.TestNestedNestedOneOf.(*Test_TestNested_TestNestedNested_G)
+					var srcOk bool
+					if src != nil {
+						_, srcOk = src.TestNestedNestedOneOf.(*Test_TestNested_TestNestedNested_G)
+					}
 					if len(oneofSubs) > 0 {
 						return fmt.Errorf("'g' has no subfields, but %s were specified", oneofSubs)
 					}

--- a/testdata/testdata.pb.setters.fm.go
+++ b/testdata/testdata.pb.setters.fm.go
@@ -169,61 +169,81 @@ func (dst *Test) SetFields(src *Test, paths ...string) error {
 			for oneofName, oneofSubs := range subPathMap {
 				switch oneofName {
 				case "d":
-					var srcOk bool
-					if src != nil {
-						_, srcOk = src.TestOneof.(*Test_D)
+					_, srcTypeOk := src.TestOneof.(*Test_D)
+					srcValid := srcTypeOk || src.TestOneof == nil || len(oneofSubs) == 0
+					if !srcValid {
+						return fmt.Errorf("attempt to set oneof 'd', while different oneof is set in source")
+					}
+					_, dstTypeOk := dst.TestOneof.(*Test_D)
+					dstValid := dstTypeOk || dst.TestOneof == nil || len(oneofSubs) == 0
+					if !dstValid {
+						return fmt.Errorf("attempt to set oneof 'd', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
 						return fmt.Errorf("'d' has no subfields, but %s were specified", oneofSubs)
 					}
-					if srcOk {
+					if srcTypeOk {
 						dst.TestOneof = src.TestOneof
 					} else {
 						dst.TestOneof = nil
 					}
 				case "e":
-					var srcOk bool
-					if src != nil {
-						_, srcOk = src.TestOneof.(*Test_CustomNameOneof)
+					_, srcTypeOk := src.TestOneof.(*Test_CustomNameOneof)
+					srcValid := srcTypeOk || src.TestOneof == nil || len(oneofSubs) == 0
+					if !srcValid {
+						return fmt.Errorf("attempt to set oneof 'e', while different oneof is set in source")
+					}
+					_, dstTypeOk := dst.TestOneof.(*Test_CustomNameOneof)
+					dstValid := dstTypeOk || dst.TestOneof == nil || len(oneofSubs) == 0
+					if !dstValid {
+						return fmt.Errorf("attempt to set oneof 'e', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
 						return fmt.Errorf("'e' has no subfields, but %s were specified", oneofSubs)
 					}
-					if srcOk {
+					if srcTypeOk {
 						dst.TestOneof = src.TestOneof
 					} else {
 						dst.TestOneof = nil
 					}
 				case "f":
-					var srcOk bool
-					if src != nil {
-						_, srcOk = src.TestOneof.(*Test_F)
+					_, srcTypeOk := src.TestOneof.(*Test_F)
+					srcValid := srcTypeOk || src.TestOneof == nil || len(oneofSubs) == 0
+					if !srcValid {
+						return fmt.Errorf("attempt to set oneof 'f', while different oneof is set in source")
+					}
+					_, dstTypeOk := dst.TestOneof.(*Test_F)
+					dstValid := dstTypeOk || dst.TestOneof == nil || len(oneofSubs) == 0
+					if !dstValid {
+						return fmt.Errorf("attempt to set oneof 'f', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
 						return fmt.Errorf("'f' has no subfields, but %s were specified", oneofSubs)
 					}
-					if srcOk {
+					if srcTypeOk {
 						dst.TestOneof = src.TestOneof
 					} else {
 						dst.TestOneof = nil
 					}
 				case "k":
-					var srcOk bool
-					if src != nil {
-						_, srcOk = src.TestOneof.(*Test_K)
+					_, srcTypeOk := src.TestOneof.(*Test_K)
+					srcValid := srcTypeOk || src.TestOneof == nil || len(oneofSubs) == 0
+					if !srcValid {
+						return fmt.Errorf("attempt to set oneof 'k', while different oneof is set in source")
+					}
+					_, dstTypeOk := dst.TestOneof.(*Test_K)
+					dstValid := dstTypeOk || dst.TestOneof == nil || len(oneofSubs) == 0
+					if !dstValid {
+						return fmt.Errorf("attempt to set oneof 'k', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
 						var newDst, newSrc *Test_TestNested
-						if srcOk {
+						if srcTypeOk {
 							newSrc = src.TestOneof.(*Test_K).K
 						}
-						var dstOk bool
-						if dst != nil {
-							_, dstOk = dst.TestOneof.(*Test_K)
-						}
-						if dstOk {
+						if dstTypeOk {
 							newDst = dst.TestOneof.(*Test_K).K
-						} else if srcOk {
+						} else if srcTypeOk {
 							newDst = &Test_TestNested{}
 							dst.TestOneof = &Test_K{K: newDst}
 						} else {
@@ -234,7 +254,7 @@ func (dst *Test) SetFields(src *Test, paths ...string) error {
 							return err
 						}
 					} else {
-						if srcOk {
+						if srcTypeOk {
 							dst.TestOneof = src.TestOneof
 						} else {
 							dst.TestOneof = nil
@@ -445,22 +465,24 @@ func (dst *Test_TestNested_TestNestedNested) SetFields(src *Test_TestNested_Test
 			for oneofName, oneofSubs := range subPathMap {
 				switch oneofName {
 				case "e":
-					var srcOk bool
-					if src != nil {
-						_, srcOk = src.TestNestedNestedOneOf.(*Test_TestNested_TestNestedNested_E)
+					_, srcTypeOk := src.TestNestedNestedOneOf.(*Test_TestNested_TestNestedNested_E)
+					srcValid := srcTypeOk || src.TestNestedNestedOneOf == nil || len(oneofSubs) == 0
+					if !srcValid {
+						return fmt.Errorf("attempt to set oneof 'e', while different oneof is set in source")
+					}
+					_, dstTypeOk := dst.TestNestedNestedOneOf.(*Test_TestNested_TestNestedNested_E)
+					dstValid := dstTypeOk || dst.TestNestedNestedOneOf == nil || len(oneofSubs) == 0
+					if !dstValid {
+						return fmt.Errorf("attempt to set oneof 'e', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
 						var newDst, newSrc *Empty
-						if srcOk {
+						if srcTypeOk {
 							newSrc = src.TestNestedNestedOneOf.(*Test_TestNested_TestNestedNested_E).E
 						}
-						var dstOk bool
-						if dst != nil {
-							_, dstOk = dst.TestNestedNestedOneOf.(*Test_TestNested_TestNestedNested_E)
-						}
-						if dstOk {
+						if dstTypeOk {
 							newDst = dst.TestNestedNestedOneOf.(*Test_TestNested_TestNestedNested_E).E
-						} else if srcOk {
+						} else if srcTypeOk {
 							newDst = &Empty{}
 							dst.TestNestedNestedOneOf = &Test_TestNested_TestNestedNested_E{E: newDst}
 						} else {
@@ -471,34 +493,46 @@ func (dst *Test_TestNested_TestNestedNested) SetFields(src *Test_TestNested_Test
 							return err
 						}
 					} else {
-						if srcOk {
+						if srcTypeOk {
 							dst.TestNestedNestedOneOf = src.TestNestedNestedOneOf
 						} else {
 							dst.TestNestedNestedOneOf = nil
 						}
 					}
 				case "f":
-					var srcOk bool
-					if src != nil {
-						_, srcOk = src.TestNestedNestedOneOf.(*Test_TestNested_TestNestedNested_F)
+					_, srcTypeOk := src.TestNestedNestedOneOf.(*Test_TestNested_TestNestedNested_F)
+					srcValid := srcTypeOk || src.TestNestedNestedOneOf == nil || len(oneofSubs) == 0
+					if !srcValid {
+						return fmt.Errorf("attempt to set oneof 'f', while different oneof is set in source")
+					}
+					_, dstTypeOk := dst.TestNestedNestedOneOf.(*Test_TestNested_TestNestedNested_F)
+					dstValid := dstTypeOk || dst.TestNestedNestedOneOf == nil || len(oneofSubs) == 0
+					if !dstValid {
+						return fmt.Errorf("attempt to set oneof 'f', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
 						return fmt.Errorf("'f' has no subfields, but %s were specified", oneofSubs)
 					}
-					if srcOk {
+					if srcTypeOk {
 						dst.TestNestedNestedOneOf = src.TestNestedNestedOneOf
 					} else {
 						dst.TestNestedNestedOneOf = nil
 					}
 				case "g":
-					var srcOk bool
-					if src != nil {
-						_, srcOk = src.TestNestedNestedOneOf.(*Test_TestNested_TestNestedNested_G)
+					_, srcTypeOk := src.TestNestedNestedOneOf.(*Test_TestNested_TestNestedNested_G)
+					srcValid := srcTypeOk || src.TestNestedNestedOneOf == nil || len(oneofSubs) == 0
+					if !srcValid {
+						return fmt.Errorf("attempt to set oneof 'g', while different oneof is set in source")
+					}
+					_, dstTypeOk := dst.TestNestedNestedOneOf.(*Test_TestNested_TestNestedNested_G)
+					dstValid := dstTypeOk || dst.TestNestedNestedOneOf == nil || len(oneofSubs) == 0
+					if !dstValid {
+						return fmt.Errorf("attempt to set oneof 'g', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
 						return fmt.Errorf("'g' has no subfields, but %s were specified", oneofSubs)
 					}
-					if srcOk {
+					if srcTypeOk {
 						dst.TestNestedNestedOneOf = src.TestNestedNestedOneOf
 					} else {
 						dst.TestNestedNestedOneOf = nil

--- a/testdata/testdata.pb.setters.fm.go
+++ b/testdata/testdata.pb.setters.fm.go
@@ -170,83 +170,56 @@ func (dst *Test) SetFields(src *Test, paths ...string) error {
 				switch oneofName {
 				case "d":
 					_, srcOk := src.TestOneof.(*Test_D)
-					if !srcOk && src.TestOneof != nil {
-						return fmt.Errorf("attempt to set oneof 'd', while different oneof is set in source")
-					}
-					_, dstOk := dst.TestOneof.(*Test_D)
-					if !dstOk && dst.TestOneof != nil {
-						return fmt.Errorf("attempt to set oneof 'd', while different oneof is set in destination")
-					}
 					if len(oneofSubs) > 0 {
 						return fmt.Errorf("'d' has no subfields, but %s were specified", oneofSubs)
 					}
-					if src != nil {
+					if srcOk {
 						dst.TestOneof = src.TestOneof
 					} else {
-						dst.TestOneof = &Test_D{}
+						dst.TestOneof = nil
 					}
 				case "e":
 					_, srcOk := src.TestOneof.(*Test_CustomNameOneof)
-					if !srcOk && src.TestOneof != nil {
-						return fmt.Errorf("attempt to set oneof 'e', while different oneof is set in source")
-					}
-					_, dstOk := dst.TestOneof.(*Test_CustomNameOneof)
-					if !dstOk && dst.TestOneof != nil {
-						return fmt.Errorf("attempt to set oneof 'e', while different oneof is set in destination")
-					}
 					if len(oneofSubs) > 0 {
 						return fmt.Errorf("'e' has no subfields, but %s were specified", oneofSubs)
 					}
-					if src != nil {
+					if srcOk {
 						dst.TestOneof = src.TestOneof
 					} else {
-						dst.TestOneof = &Test_CustomNameOneof{}
+						dst.TestOneof = nil
 					}
 				case "f":
 					_, srcOk := src.TestOneof.(*Test_F)
-					if !srcOk && src.TestOneof != nil {
-						return fmt.Errorf("attempt to set oneof 'f', while different oneof is set in source")
-					}
-					_, dstOk := dst.TestOneof.(*Test_F)
-					if !dstOk && dst.TestOneof != nil {
-						return fmt.Errorf("attempt to set oneof 'f', while different oneof is set in destination")
-					}
 					if len(oneofSubs) > 0 {
 						return fmt.Errorf("'f' has no subfields, but %s were specified", oneofSubs)
 					}
-					if src != nil {
+					if srcOk {
 						dst.TestOneof = src.TestOneof
 					} else {
 						dst.TestOneof = nil
 					}
 				case "k":
 					_, srcOk := src.TestOneof.(*Test_K)
-					if !srcOk && src.TestOneof != nil {
-						return fmt.Errorf("attempt to set oneof 'k', while different oneof is set in source")
-					}
-					_, dstOk := dst.TestOneof.(*Test_K)
-					if !dstOk && dst.TestOneof != nil {
-						return fmt.Errorf("attempt to set oneof 'k', while different oneof is set in destination")
-					}
 					if len(oneofSubs) > 0 {
 						var newDst, newSrc *Test_TestNested
-						if !srcOk && !dstOk {
-							continue
-						}
 						if srcOk {
 							newSrc = src.TestOneof.(*Test_K).K
 						}
+						_, dstOk := dst.TestOneof.(*Test_K)
 						if dstOk {
 							newDst = dst.TestOneof.(*Test_K).K
-						} else {
+						} else if srcOk {
 							newDst = &Test_TestNested{}
 							dst.TestOneof = &Test_K{K: newDst}
+						} else {
+							dst.TestOneof = nil
+							continue
 						}
 						if err := newDst.SetFields(newSrc, oneofSubs...); err != nil {
 							return err
 						}
 					} else {
-						if src != nil {
+						if srcOk {
 							dst.TestOneof = src.TestOneof
 						} else {
 							dst.TestOneof = nil
@@ -458,32 +431,26 @@ func (dst *Test_TestNested_TestNestedNested) SetFields(src *Test_TestNested_Test
 				switch oneofName {
 				case "e":
 					_, srcOk := src.TestNestedNestedOneOf.(*Test_TestNested_TestNestedNested_E)
-					if !srcOk && src.TestNestedNestedOneOf != nil {
-						return fmt.Errorf("attempt to set oneof 'e', while different oneof is set in source")
-					}
-					_, dstOk := dst.TestNestedNestedOneOf.(*Test_TestNested_TestNestedNested_E)
-					if !dstOk && dst.TestNestedNestedOneOf != nil {
-						return fmt.Errorf("attempt to set oneof 'e', while different oneof is set in destination")
-					}
 					if len(oneofSubs) > 0 {
 						var newDst, newSrc *Empty
-						if !srcOk && !dstOk {
-							continue
-						}
 						if srcOk {
 							newSrc = src.TestNestedNestedOneOf.(*Test_TestNested_TestNestedNested_E).E
 						}
+						_, dstOk := dst.TestNestedNestedOneOf.(*Test_TestNested_TestNestedNested_E)
 						if dstOk {
 							newDst = dst.TestNestedNestedOneOf.(*Test_TestNested_TestNestedNested_E).E
-						} else {
+						} else if srcOk {
 							newDst = &Empty{}
 							dst.TestNestedNestedOneOf = &Test_TestNested_TestNestedNested_E{E: newDst}
+						} else {
+							dst.TestNestedNestedOneOf = nil
+							continue
 						}
 						if err := newDst.SetFields(newSrc, oneofSubs...); err != nil {
 							return err
 						}
 					} else {
-						if src != nil {
+						if srcOk {
 							dst.TestNestedNestedOneOf = src.TestNestedNestedOneOf
 						} else {
 							dst.TestNestedNestedOneOf = nil
@@ -491,34 +458,20 @@ func (dst *Test_TestNested_TestNestedNested) SetFields(src *Test_TestNested_Test
 					}
 				case "f":
 					_, srcOk := src.TestNestedNestedOneOf.(*Test_TestNested_TestNestedNested_F)
-					if !srcOk && src.TestNestedNestedOneOf != nil {
-						return fmt.Errorf("attempt to set oneof 'f', while different oneof is set in source")
-					}
-					_, dstOk := dst.TestNestedNestedOneOf.(*Test_TestNested_TestNestedNested_F)
-					if !dstOk && dst.TestNestedNestedOneOf != nil {
-						return fmt.Errorf("attempt to set oneof 'f', while different oneof is set in destination")
-					}
 					if len(oneofSubs) > 0 {
 						return fmt.Errorf("'f' has no subfields, but %s were specified", oneofSubs)
 					}
-					if src != nil {
+					if srcOk {
 						dst.TestNestedNestedOneOf = src.TestNestedNestedOneOf
 					} else {
-						dst.TestNestedNestedOneOf = &Test_TestNested_TestNestedNested_F{}
+						dst.TestNestedNestedOneOf = nil
 					}
 				case "g":
 					_, srcOk := src.TestNestedNestedOneOf.(*Test_TestNested_TestNestedNested_G)
-					if !srcOk && src.TestNestedNestedOneOf != nil {
-						return fmt.Errorf("attempt to set oneof 'g', while different oneof is set in source")
-					}
-					_, dstOk := dst.TestNestedNestedOneOf.(*Test_TestNested_TestNestedNested_G)
-					if !dstOk && dst.TestNestedNestedOneOf != nil {
-						return fmt.Errorf("attempt to set oneof 'g', while different oneof is set in destination")
-					}
 					if len(oneofSubs) > 0 {
 						return fmt.Errorf("'g' has no subfields, but %s were specified", oneofSubs)
 					}
-					if src != nil {
+					if srcOk {
 						dst.TestNestedNestedOneOf = src.TestNestedNestedOneOf
 					} else {
 						dst.TestNestedNestedOneOf = nil

--- a/tools.go
+++ b/tools.go
@@ -1,3 +1,4 @@
+//go:build tools
 // +build tools
 
 package tools


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://github.com/TheThingsNetwork/lorawan-stack/pull/5326

#### Changes
<!-- What are the changes made in this pull request? -->

- Do not check if the source or destination `oneof` fields have the correct type, but instead behave as if they are `nil` on mismatch.
  - Note that this is allowed only if no subfields are provided

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

This is motivated by the ADR settings PR. Before this PR, it would be impossible to change the `oneof` field without clearing the field in between uses. This 'clear' operation (setting to `nil`) was required because the generated code would complain that the source and the destination `oneof` type are mismatching. 

The effect on TTS can be seen at https://github.com/TheThingsNetwork/lorawan-stack/commit/453b8350169237574036694622a80dc155bc9d20