### PR TITLE
Fix oneof unset handling

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: '~1.17'
+        go-version: '~1.18'
     - name: Initialize Go module cache
       uses: actions/cache@v2
       with:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/TheThingsIndustries/protoc-gen-fieldmask
 
-go 1.17
+go 1.18
 
 replace github.com/lyft/protoc-gen-star => github.com/TheThingsIndustries/protoc-gen-star v0.5.2-gogo.1
 

--- a/main_test.go
+++ b/main_test.go
@@ -106,7 +106,7 @@ func TestGolden(t *testing.T) {
 
 		goldenPath := filepath.Join(".", strings.TrimPrefix(path, filepath.Join(workDir, "github.com", "TheThingsIndustries", "protoc-gen-fieldmask")))
 		if *regenerate {
-			if err := ioutil.WriteFile(goldenPath, b, 0666); err != nil {
+			if err := ioutil.WriteFile(goldenPath, b, 0o666); err != nil {
 				t.Errorf("Failed to write golden file at `%s`: %s", goldenPath, err)
 			}
 			return nil
@@ -669,16 +669,22 @@ var setFieldsTestCases = []struct {
 		},
 	},
 	{
-		Name:        "source testOneof.k.a.testNestedNestedOneOf.g empty",
-		Destination: &testdata.Test{},
-		Source: &testdata.Test{
+		Name: "source testOneof.k.a.testNestedNestedOneOf.g empty",
+		Destination: &testdata.Test{
 			TestOneof: &testdata.Test_K{
 				K: &testdata.Test_TestNested{
-					A: &testdata.Test_TestNested_TestNestedNested{},
+					A: &testdata.Test_TestNested_TestNestedNested{
+						TestNestedNestedOneOf: &testdata.Test_TestNested_TestNestedNested_G{
+							G: &types.UInt64Value{
+								Value: 42,
+							},
+						},
+					},
 				},
 			},
 		},
-		Paths: []string{"testOneof.k.a.testNestedNestedOneOf.g"},
+		Source: &testdata.Test{},
+		Paths:  []string{"testOneof.k.a.testNestedNestedOneOf.g"},
 		Result: &testdata.Test{
 			TestOneof: &testdata.Test_K{
 				K: &testdata.Test_TestNested{
@@ -769,14 +775,8 @@ var setFieldsTestCases = []struct {
 		},
 	},
 	{
-		Name: "destination testOneof.k.a.testNestedNestedOneOf.g empty",
-		Destination: &testdata.Test{
-			TestOneof: &testdata.Test_K{
-				K: &testdata.Test_TestNested{
-					A: &testdata.Test_TestNested_TestNestedNested{},
-				},
-			},
-		},
+		Name:        "destination testOneof.k.a.testNestedNestedOneOf.g empty",
+		Destination: &testdata.Test{},
 		Source: &testdata.Test{
 			TestOneof: &testdata.Test_K{
 				K: &testdata.Test_TestNested{

--- a/module/setter.go
+++ b/module/setter.go
@@ -36,14 +36,15 @@ func (m *setterModule) buildSetFieldsCase(buf *strings.Builder, imports importMa
 	buildIndented(buf, tabCount, fmt.Sprintf(`case "%s":`, f.Name()))
 
 	if f.InOneOf() {
-		buildIndented(buf, tabCount+1, fmt.Sprintf(`_, srcTypeOk := src.%s.(*%s)
-srcValid := srcTypeOk || src.%s == nil || len(oneofSubs) == 0
-if !srcValid {
+		buildIndented(buf, tabCount+1, fmt.Sprintf(`var srcTypeOk bool
+if src != nil {
+	_, srcTypeOk = src.%s.(*%s)
+}
+if srcValid := srcTypeOk || src == nil || src.%s == nil || len(oneofSubs) == 0; !srcValid {
 	return fmt.Errorf("attempt to set oneof '%s', while different oneof is set in source")
 }
 _, dstTypeOk := dst.%s.(*%s)
-dstValid := dstTypeOk || dst.%s == nil || len(oneofSubs) == 0
-if !dstValid {
+if dstValid := dstTypeOk || dst.%s == nil || len(oneofSubs) == 0; !dstValid {
 	return fmt.Errorf("attempt to set oneof '%s', while different oneof is set in destination")
 }`,
 			m.ctx.Name(f.OneOf()), m.ctx.OneofOption(f),

--- a/testdata/testdata.pb.setters.fm.go
+++ b/testdata/testdata.pb.setters.fm.go
@@ -169,14 +169,15 @@ func (dst *Test) SetFields(src *Test, paths ...string) error {
 			for oneofName, oneofSubs := range subPathMap {
 				switch oneofName {
 				case "d":
-					_, srcTypeOk := src.TestOneof.(*Test_D)
-					srcValid := srcTypeOk || src.TestOneof == nil || len(oneofSubs) == 0
-					if !srcValid {
+					var srcTypeOk bool
+					if src != nil {
+						_, srcTypeOk = src.TestOneof.(*Test_D)
+					}
+					if srcValid := srcTypeOk || src == nil || src.TestOneof == nil || len(oneofSubs) == 0; !srcValid {
 						return fmt.Errorf("attempt to set oneof 'd', while different oneof is set in source")
 					}
 					_, dstTypeOk := dst.TestOneof.(*Test_D)
-					dstValid := dstTypeOk || dst.TestOneof == nil || len(oneofSubs) == 0
-					if !dstValid {
+					if dstValid := dstTypeOk || dst.TestOneof == nil || len(oneofSubs) == 0; !dstValid {
 						return fmt.Errorf("attempt to set oneof 'd', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
@@ -188,14 +189,15 @@ func (dst *Test) SetFields(src *Test, paths ...string) error {
 						dst.TestOneof = nil
 					}
 				case "e":
-					_, srcTypeOk := src.TestOneof.(*Test_CustomNameOneof)
-					srcValid := srcTypeOk || src.TestOneof == nil || len(oneofSubs) == 0
-					if !srcValid {
+					var srcTypeOk bool
+					if src != nil {
+						_, srcTypeOk = src.TestOneof.(*Test_CustomNameOneof)
+					}
+					if srcValid := srcTypeOk || src == nil || src.TestOneof == nil || len(oneofSubs) == 0; !srcValid {
 						return fmt.Errorf("attempt to set oneof 'e', while different oneof is set in source")
 					}
 					_, dstTypeOk := dst.TestOneof.(*Test_CustomNameOneof)
-					dstValid := dstTypeOk || dst.TestOneof == nil || len(oneofSubs) == 0
-					if !dstValid {
+					if dstValid := dstTypeOk || dst.TestOneof == nil || len(oneofSubs) == 0; !dstValid {
 						return fmt.Errorf("attempt to set oneof 'e', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
@@ -207,14 +209,15 @@ func (dst *Test) SetFields(src *Test, paths ...string) error {
 						dst.TestOneof = nil
 					}
 				case "f":
-					_, srcTypeOk := src.TestOneof.(*Test_F)
-					srcValid := srcTypeOk || src.TestOneof == nil || len(oneofSubs) == 0
-					if !srcValid {
+					var srcTypeOk bool
+					if src != nil {
+						_, srcTypeOk = src.TestOneof.(*Test_F)
+					}
+					if srcValid := srcTypeOk || src == nil || src.TestOneof == nil || len(oneofSubs) == 0; !srcValid {
 						return fmt.Errorf("attempt to set oneof 'f', while different oneof is set in source")
 					}
 					_, dstTypeOk := dst.TestOneof.(*Test_F)
-					dstValid := dstTypeOk || dst.TestOneof == nil || len(oneofSubs) == 0
-					if !dstValid {
+					if dstValid := dstTypeOk || dst.TestOneof == nil || len(oneofSubs) == 0; !dstValid {
 						return fmt.Errorf("attempt to set oneof 'f', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
@@ -226,14 +229,15 @@ func (dst *Test) SetFields(src *Test, paths ...string) error {
 						dst.TestOneof = nil
 					}
 				case "k":
-					_, srcTypeOk := src.TestOneof.(*Test_K)
-					srcValid := srcTypeOk || src.TestOneof == nil || len(oneofSubs) == 0
-					if !srcValid {
+					var srcTypeOk bool
+					if src != nil {
+						_, srcTypeOk = src.TestOneof.(*Test_K)
+					}
+					if srcValid := srcTypeOk || src == nil || src.TestOneof == nil || len(oneofSubs) == 0; !srcValid {
 						return fmt.Errorf("attempt to set oneof 'k', while different oneof is set in source")
 					}
 					_, dstTypeOk := dst.TestOneof.(*Test_K)
-					dstValid := dstTypeOk || dst.TestOneof == nil || len(oneofSubs) == 0
-					if !dstValid {
+					if dstValid := dstTypeOk || dst.TestOneof == nil || len(oneofSubs) == 0; !dstValid {
 						return fmt.Errorf("attempt to set oneof 'k', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
@@ -465,14 +469,15 @@ func (dst *Test_TestNested_TestNestedNested) SetFields(src *Test_TestNested_Test
 			for oneofName, oneofSubs := range subPathMap {
 				switch oneofName {
 				case "e":
-					_, srcTypeOk := src.TestNestedNestedOneOf.(*Test_TestNested_TestNestedNested_E)
-					srcValid := srcTypeOk || src.TestNestedNestedOneOf == nil || len(oneofSubs) == 0
-					if !srcValid {
+					var srcTypeOk bool
+					if src != nil {
+						_, srcTypeOk = src.TestNestedNestedOneOf.(*Test_TestNested_TestNestedNested_E)
+					}
+					if srcValid := srcTypeOk || src == nil || src.TestNestedNestedOneOf == nil || len(oneofSubs) == 0; !srcValid {
 						return fmt.Errorf("attempt to set oneof 'e', while different oneof is set in source")
 					}
 					_, dstTypeOk := dst.TestNestedNestedOneOf.(*Test_TestNested_TestNestedNested_E)
-					dstValid := dstTypeOk || dst.TestNestedNestedOneOf == nil || len(oneofSubs) == 0
-					if !dstValid {
+					if dstValid := dstTypeOk || dst.TestNestedNestedOneOf == nil || len(oneofSubs) == 0; !dstValid {
 						return fmt.Errorf("attempt to set oneof 'e', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
@@ -500,14 +505,15 @@ func (dst *Test_TestNested_TestNestedNested) SetFields(src *Test_TestNested_Test
 						}
 					}
 				case "f":
-					_, srcTypeOk := src.TestNestedNestedOneOf.(*Test_TestNested_TestNestedNested_F)
-					srcValid := srcTypeOk || src.TestNestedNestedOneOf == nil || len(oneofSubs) == 0
-					if !srcValid {
+					var srcTypeOk bool
+					if src != nil {
+						_, srcTypeOk = src.TestNestedNestedOneOf.(*Test_TestNested_TestNestedNested_F)
+					}
+					if srcValid := srcTypeOk || src == nil || src.TestNestedNestedOneOf == nil || len(oneofSubs) == 0; !srcValid {
 						return fmt.Errorf("attempt to set oneof 'f', while different oneof is set in source")
 					}
 					_, dstTypeOk := dst.TestNestedNestedOneOf.(*Test_TestNested_TestNestedNested_F)
-					dstValid := dstTypeOk || dst.TestNestedNestedOneOf == nil || len(oneofSubs) == 0
-					if !dstValid {
+					if dstValid := dstTypeOk || dst.TestNestedNestedOneOf == nil || len(oneofSubs) == 0; !dstValid {
 						return fmt.Errorf("attempt to set oneof 'f', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
@@ -519,14 +525,15 @@ func (dst *Test_TestNested_TestNestedNested) SetFields(src *Test_TestNested_Test
 						dst.TestNestedNestedOneOf = nil
 					}
 				case "g":
-					_, srcTypeOk := src.TestNestedNestedOneOf.(*Test_TestNested_TestNestedNested_G)
-					srcValid := srcTypeOk || src.TestNestedNestedOneOf == nil || len(oneofSubs) == 0
-					if !srcValid {
+					var srcTypeOk bool
+					if src != nil {
+						_, srcTypeOk = src.TestNestedNestedOneOf.(*Test_TestNested_TestNestedNested_G)
+					}
+					if srcValid := srcTypeOk || src == nil || src.TestNestedNestedOneOf == nil || len(oneofSubs) == 0; !srcValid {
 						return fmt.Errorf("attempt to set oneof 'g', while different oneof is set in source")
 					}
 					_, dstTypeOk := dst.TestNestedNestedOneOf.(*Test_TestNested_TestNestedNested_G)
-					dstValid := dstTypeOk || dst.TestNestedNestedOneOf == nil || len(oneofSubs) == 0
-					if !dstValid {
+					if dstValid := dstTypeOk || dst.TestNestedNestedOneOf == nil || len(oneofSubs) == 0; !dstValid {
 						return fmt.Errorf("attempt to set oneof 'g', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://sentry.io/organizations/the-things-industries/issues/3466321594/?alert_rule_id=1003576&alert_timestamp=1659197687403&alert_type=email&environment=ttich-staging-eu1&project=2682566&referrer=alert_email

#### Changes
<!-- What are the changes made in this pull request? -->

- Upgrade to Go 1.18
- Fix `oneof` unset handling
